### PR TITLE
Add history popup menu

### DIFF
--- a/src/renderer/src/components/InputHistoryMenu.tsx
+++ b/src/renderer/src/components/InputHistoryMenu.tsx
@@ -1,21 +1,16 @@
 import { useEffect, useRef } from 'react';
+
 import { useClickOutside } from '@/hooks/useClickOutside';
 
-interface Props {
+type Props = {
   items: string[];
   highlightedIndex: number;
   setHighlightedIndex: (index: number) => void;
   onSelect: (item: string) => void;
   onClose: () => void;
-}
+};
 
-export const InputHistoryMenu = ({
-  items,
-  highlightedIndex,
-  setHighlightedIndex,
-  onSelect,
-  onClose,
-}: Props) => {
+export const InputHistoryMenu = ({ items, highlightedIndex, setHighlightedIndex, onSelect, onClose }: Props) => {
   const menuRef = useRef<HTMLDivElement>(null);
   useClickOutside(menuRef, onClose);
 
@@ -44,4 +39,3 @@ export const InputHistoryMenu = ({
     </div>
   );
 };
-

--- a/src/renderer/src/components/InputHistoryMenu.tsx
+++ b/src/renderer/src/components/InputHistoryMenu.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+interface Props {
+  items: string[];
+  highlightedIndex: number;
+  setHighlightedIndex: (index: number) => void;
+  onSelect: (item: string) => void;
+  onClose: () => void;
+}
+
+export const InputHistoryMenu = ({
+  items,
+  highlightedIndex,
+  setHighlightedIndex,
+  onSelect,
+  onClose,
+}: Props) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, onClose);
+
+  useEffect(() => {
+    if (menuRef.current) {
+      menuRef.current.scrollTop = menuRef.current.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute bottom-full mb-1 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg z-10 max-h-48 overflow-y-auto scrollbar-thin scrollbar-track-neutral-800 scrollbar-thumb-neutral-700 hover:scrollbar-thumb-neutral-600"
+    >
+      {items.map((item, index) => (
+        <div
+          key={index}
+          ref={index === highlightedIndex ? (el) => el?.scrollIntoView({ block: 'nearest' }) : null}
+          className={`px-3 py-1 text-left text-xs cursor-pointer hover:bg-neutral-700 ${index === highlightedIndex ? 'bg-neutral-700' : ''}`}
+          onMouseEnter={() => setHighlightedIndex(index)}
+          onClick={() => onSelect(item)}
+        >
+          {item}
+        </div>
+      ))}
+    </div>
+  );
+};
+

--- a/src/renderer/src/components/InputHistoryMenu.tsx
+++ b/src/renderer/src/components/InputHistoryMenu.tsx
@@ -8,10 +8,13 @@ type Props = {
   setHighlightedIndex: (index: number) => void;
   onSelect: (item: string) => void;
   onClose: () => void;
+  onScrollTop?: () => void;
+  keepHighlightAtTop?: boolean;
 };
 
-export const InputHistoryMenu = ({ items, highlightedIndex, setHighlightedIndex, onSelect, onClose }: Props) => {
+export const InputHistoryMenu = ({ items, highlightedIndex, setHighlightedIndex, onSelect, onClose, onScrollTop, keepHighlightAtTop = false }: Props) => {
   const menuRef = useRef<HTMLDivElement>(null);
+  const prevScrollTop = useRef(0);
   useClickOutside(menuRef, onClose);
 
   useEffect(() => {
@@ -20,15 +23,27 @@ export const InputHistoryMenu = ({ items, highlightedIndex, setHighlightedIndex,
     }
   }, []);
 
+  const handleScroll = () => {
+    const el = menuRef.current;
+    if (!el) {
+      return;
+    }
+    if (el.scrollTop === 0 && prevScrollTop.current > 0) {
+      onScrollTop?.();
+    }
+    prevScrollTop.current = el.scrollTop;
+  };
+
   return (
     <div
       ref={menuRef}
+      onScroll={handleScroll}
       className="absolute bottom-full mb-1 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg z-10 max-h-48 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-track-neutral-800 scrollbar-thumb-neutral-700 hover:scrollbar-thumb-neutral-600 max-w-full"
     >
       {items.map((item, index) => (
         <div
           key={index}
-          ref={index === highlightedIndex ? (el) => el?.scrollIntoView({ block: 'nearest' }) : null}
+          ref={index === highlightedIndex ? (el) => el?.scrollIntoView({ block: keepHighlightAtTop ? 'start' : 'nearest' }) : null}
           className={`px-3 py-1 text-left text-xs cursor-pointer hover:bg-neutral-700 truncate ${index === highlightedIndex ? 'bg-neutral-700' : ''}`}
           onMouseEnter={() => setHighlightedIndex(index)}
           onClick={() => onSelect(item)}

--- a/src/renderer/src/components/InputHistoryMenu.tsx
+++ b/src/renderer/src/components/InputHistoryMenu.tsx
@@ -23,13 +23,13 @@ export const InputHistoryMenu = ({ items, highlightedIndex, setHighlightedIndex,
   return (
     <div
       ref={menuRef}
-      className="absolute bottom-full mb-1 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg z-10 max-h-48 overflow-y-auto scrollbar-thin scrollbar-track-neutral-800 scrollbar-thumb-neutral-700 hover:scrollbar-thumb-neutral-600"
+      className="absolute bottom-full mb-1 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg z-10 max-h-48 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-track-neutral-800 scrollbar-thumb-neutral-700 hover:scrollbar-thumb-neutral-600 max-w-full"
     >
       {items.map((item, index) => (
         <div
           key={index}
           ref={index === highlightedIndex ? (el) => el?.scrollIntoView({ block: 'nearest' }) : null}
-          className={`px-3 py-1 text-left text-xs cursor-pointer hover:bg-neutral-700 ${index === highlightedIndex ? 'bg-neutral-700' : ''}`}
+          className={`px-3 py-1 text-left text-xs cursor-pointer hover:bg-neutral-700 truncate ${index === highlightedIndex ? 'bg-neutral-700' : ''}`}
           onMouseEnter={() => setHighlightedIndex(index)}
           onClick={() => onSelect(item)}
         >

--- a/src/renderer/src/components/PromptField.tsx
+++ b/src/renderer/src/components/PromptField.tsx
@@ -99,7 +99,6 @@ export const PromptField = React.forwardRef<PromptFieldRef, Props>(
     const [placeholderIndex] = useState(Math.floor(Math.random() * 16));
     const [cursorPosition, setCursorPosition] = useState({ top: 0, left: 0 });
     const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] = useState(-1);
-    const [historyIndex, setHistoryIndex] = useState<number>(-1);
     const [historyMenuVisible, setHistoryMenuVisible] = useState(false);
     const [highlightedHistoryItemIndex, setHighlightedHistoryItemIndex] = useState(0);
     const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
@@ -254,7 +253,6 @@ export const PromptField = React.forwardRef<PromptFieldRef, Props>(
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newText = e.target.value;
       setText(newText);
-      setHistoryIndex(-1);
 
       const word = getCurrentWord(newText, e.target.selectionStart);
       setHighlightedSuggestionIndex(-1);
@@ -318,7 +316,6 @@ export const PromptField = React.forwardRef<PromptFieldRef, Props>(
       setCurrentWord('');
       setSuggestionsVisible(false);
       setHighlightedSuggestionIndex(-1);
-      setHistoryIndex(-1);
     };
 
     const handleSubmit = () => {


### PR DESCRIPTION
## Summary
- add `InputHistoryMenu` component for command history
- show popup menu instead of cycling history with arrow keys
- scroll menu to bottom and keep selection visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*